### PR TITLE
Updating Contributing section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,11 @@ The book is made possible with [easybook](https://packagist.org/packages/easyboo
 
 ## Contributing ##
 
-1. Download http://easybook-project.org/
+All contributions from non-project developers must go through a pull 
+request and approved by a project developer before being merged. This 
+is to ensure proper review of all proposed changes.
 
-2. Fork 
-
-    https://github.com/harikt/the-book-on-aura
-
-3. Clone the repo to the `docs` folder
-    
-    git clone https://github.com/username/the-book-on-aura
-    
-4. Edit the markdown chapters in the `docs/the-book-on-aura/Contents` 
-folder.
-
-5. Try yourself rendering the output as 
-
-    ./book publish the-book-on-aura website
-    
-Open `index.html` file located at `doc/the-book-on-aura/Output/website/book/` folder.
+Fork the project, make your changes, and send us a pull request.
 
 ## Licence ##
 


### PR DESCRIPTION
Prior to this change, the Contributing section referenced cloning https://github.com/harikt/the-book-on-aura , the previous location for the Aura manual. Now that the manual has been merged into the repository, the Contributing section has been rewritten to remove references to the book on aura repository (using a modified version of the Composer README.md contributing section).

This change potentially resolves Issue #16.
