### PR TITLE
Fix duplicated row in router.md

### DIFF
--- a/manuals/2.0/en/router.md
+++ b/manuals/2.0/en/router.md
@@ -410,12 +410,6 @@ That method call will result in the following routes being added:
       <td>Create a new resource</td>
     </tr>
     <tr>
-      <td>blog.create</td>
-      <td>POST</td>
-      <td>/blog</td>
-      <td>Create a new resource</td>
-    </tr>
-    <tr>
       <td>blog.update</td>
       <td>PATCH</td>
       <td>/blog/{id}</td>


### PR DESCRIPTION
I just noticed that there are duplicated row (blog.create) in table in the section "Attaching REST
Resource Routes". Please merge it if it's right :)